### PR TITLE
Patch to add support for Python 3.x

### DIFF
--- a/pytradier/__init__.py
+++ b/pytradier/__init__.py
@@ -1,3 +1,3 @@
-from tradier import Tradier
+from .tradier import Tradier
 
 __all__ = ['Tradier']

--- a/pytradier/account/__init__.py
+++ b/pytradier/account/__init__.py
@@ -1,9 +1,9 @@
-from balance import Balance
-from costbasis import CostBasis
-from history import History
-from orderstatus import OrderStatus
-from orders import Orders
-from positions import Positions
+from .balance import Balance
+from .costbasis import CostBasis
+from .history import History
+from .orderstatus import OrderStatus
+from .orders import Orders
+from .positions import Positions
 
 
-from account import Account
+from .account import Account

--- a/pytradier/account/account.py
+++ b/pytradier/account/account.py
@@ -1,9 +1,9 @@
-from balance import Balance
-from costbasis import CostBasis
-from history import History
-from orders import Orders
-from orderstatus import OrderStatus
-from positions import Positions
+from .balance import Balance
+from .costbasis import CostBasis
+from .history import History
+from .orders import Orders
+from .orderstatus import OrderStatus
+from .positions import Positions
 
 class Account:
     def __init__(self):

--- a/pytradier/account/balance.py
+++ b/pytradier/account/balance.py
@@ -25,14 +25,14 @@ class Balance(Base, AccountHelper):
 
 
     def _parse_response(self, attribute, **config):
-        if 'update' in config.keys() and config['update'] is False:
+        if 'update' in list(config.keys()) and config['update'] is False:
             pass
 
         else:
             # update the data if the `update` parameter is true
             self.update_data()  # updates by default, user must specify to not update from the API
 
-        if 'inner' in config.keys():
+        if 'inner' in list(config.keys()):
 
             return self._data['balances'][attribute][config['inner']]
 

--- a/pytradier/base.py
+++ b/pytradier/base.py
@@ -66,7 +66,7 @@ class Base(object):
         # returns the data from the API response in a dictionary for, {symbol0: data0, symbol1: data1, symbol2: data2}
         # overrides from Base super since response must be a dictionary
 
-        if 'update' in config.keys() and config['update'] is False:
+        if 'update' in list(config.keys()) and config['update'] is False:
             # update the data if the `update` parameter is true
             pass
 
@@ -78,7 +78,7 @@ class Base(object):
 
         for response in self._key:
             # more than one symbol supplied, loop through each one
-            if attribute in response.keys():
+            if attribute in list(response.keys()):
                 response_load[response[self._inner_key]] = response[attribute]
 
             else:

--- a/pytradier/company/__init__.py
+++ b/pytradier/company/__init__.py
@@ -1,16 +1,16 @@
-from action import Action
-from calendar import Calendar
-from chain import Chain
-from dividend import Dividend
-from history import History
-from info import Info
-from ratio import Ratio
-from report import Report
-from stats import Stats
-from timesales import TimeSales
+from .action import Action
+from .calendar import Calendar
+from .chain import Chain
+from .dividend import Dividend
+from .history import History
+from .info import Info
+from .ratio import Ratio
+from .report import Report
+from .stats import Stats
+from .timesales import TimeSales
 
 
 # from securities.stock import Stock
 # from securities.option import Option
 
-from company import Company
+from .company import Company

--- a/pytradier/company/company.py
+++ b/pytradier/company/company.py
@@ -5,9 +5,9 @@
 # from ratio import Ratio
 # from report import Report
 # from stats import Stats
-from chain import Chain
-from history import History
-from timesales import TimeSales
+from .chain import Chain
+from .history import History
+from .timesales import TimeSales
 
 class Company:
     def __init__(self, symbol):

--- a/pytradier/market/__init__.py
+++ b/pytradier/market/__init__.py
@@ -1,6 +1,6 @@
-from calendar import Calendar
-from lookup import Lookup
-from search import Search
-from status import Status
+from .calendar import Calendar
+from .lookup import Lookup
+from .search import Search
+from .status import Status
 
-from market import Market
+from .market import Market

--- a/pytradier/market/lookup.py
+++ b/pytradier/market/lookup.py
@@ -37,13 +37,13 @@ class Lookup(Base):
 
         self._payload = {}
 
-        if 'symbol' in query.keys():
+        if 'symbol' in list(query.keys()):
             self._payload['q'] = query['symbol']
 
-        if 'type' in query.keys():
+        if 'type' in list(query.keys()):
             self._payload['type'] = query['type']
 
-        if 'exchange' in query.keys():
+        if 'exchange' in list(query.keys()):
             self._payload['exchanges'] = query['exchange']
 
         self._path = API_PATH['lookup']

--- a/pytradier/market/market.py
+++ b/pytradier/market/market.py
@@ -1,7 +1,7 @@
-from calendar import Calendar
-from lookup import Lookup
-from search import Search
-from status import Status
+from .calendar import Calendar
+from .lookup import Lookup
+from .search import Search
+from .status import Status
 
 class Market:
 

--- a/pytradier/market/search.py
+++ b/pytradier/market/search.py
@@ -8,10 +8,10 @@ class Search(Base):
 
         self._payload = {}
 
-        if 'symbol' in query.keys():
+        if 'symbol' in list(query.keys()):
             self._payload['q'] = query['symbol']
 
-        if 'indexes' in query.keys():
+        if 'indexes' in list(query.keys()):
             self._payload['indexes'] = query['type']
 
         self._path = API_PATH['search']

--- a/pytradier/market/status.py
+++ b/pytradier/market/status.py
@@ -19,7 +19,7 @@ class Status(Base):
         # returns the data from the API response in a dictionary for, {symbol0: data0, symbol1: data1, symbol2: data2}
         # overrides from Base super since response must be a dictionary
 
-        if 'update' in config.keys() and config['update'] is False:
+        if 'update' in list(config.keys()) and config['update'] is False:
             # update the data if the `update` parameter is true
             pass
 
@@ -56,7 +56,7 @@ class Status(Base):
         """
         response = self._parse_response('timestamp', **config)
 
-        if 'style' in config.keys():
+        if 'style' in list(config.keys()):
             # user has specified style of time response
 
             if config['style'] is 'epoch':

--- a/pytradier/order/__init__.py
+++ b/pytradier/order/__init__.py
@@ -1,1 +1,1 @@
-from order import Order
+from .order import Order

--- a/pytradier/securities/__init__.py
+++ b/pytradier/securities/__init__.py
@@ -1,2 +1,2 @@
-from option import Option
-from stock import Stock
+from .option import Option
+from .stock import Stock

--- a/pytradier/securities/quote.py
+++ b/pytradier/securities/quote.py
@@ -24,7 +24,7 @@ class Quote(Base):
         # returns the data from the API response in a dictionary for, {symbol0: data0, symbol1: data1, symbol2: data2}
         # overrides from Base super since response must be a dictionary
 
-        if 'update' in config.keys() and config['update'] is False:
+        if 'update' in list(config.keys()) and config['update'] is False:
             # update the data if the `update` parameter is true
             pass
 
@@ -72,7 +72,7 @@ class Quote(Base):
         self._symbol_load = ','.join(self._symbols)  # change form from array to CSV: [AAPL, MSFT] -> AAPL,MSFT
         self._payload = {'symbols': self._symbol_load}  # prepare the payload
 
-        if 'update' in config.keys() and config['update'] is False:
+        if 'update' in list(config.keys()) and config['update'] is False:
             # update the data if the `update` parameter is true
             pass
 

--- a/pytradier/tradier.py
+++ b/pytradier/tradier.py
@@ -1,12 +1,12 @@
 
-from const import API_ENDPOINT
+from .const import API_ENDPOINT
 
 from . import company
 from . import account
 from . import order
 from . import market
 
-from securities import stock, option
+from .securities import stock, option
 
 from .exceptions import ClientException
 


### PR DESCRIPTION
I run 2to3 utility on all PyTradier sources to make the library compatible with Python 3.x. I then checked the code works using a simple script and Python 2.7 and Python 3.6 from Anaconda package:

```
import pytradier

tradier = pytradier.Tradier(token='<TOKEN>')
stock = pytradier.securities.Stock('FDX')

print(stock.close())
```

Code works both in Python 2.7 and in Python 3.6.