### PR TITLE
Added "Long term stock exchange" to const.py

### DIFF
--- a/pytradier/const.py
+++ b/pytradier/const.py
@@ -74,6 +74,7 @@ EXCHANGE_CODES = {
 	'I': 'International Securities Exchange',
 	'J': 'Direct Edge A',
 	'K': 'Direct Edge X',
+	'L': 'Long Term Stock Exchange',
 	'M': 'Chicago Stock Exchange',
 	'N': 'NYSE',
 	'P': 'NYSE Arca',


### PR DESCRIPTION
`const.py` was missing the newly added "Long term stock exchange" that uses code `L`.