### PR TITLE
Fix lookup in the case where ticker symbol searched does not exist

### DIFF
--- a/pytradier/market/lookup.py
+++ b/pytradier/market/lookup.py
@@ -51,7 +51,10 @@ class Lookup(Base):
                                         path=self._path,
                                         payload=self._payload)
 
-        self._key = self._data['securities']['security']
+        if self._data['securities'] is not None:
+            self._key = self._data['securities']['security']
+        else:
+            self._key = []
         self._inner_key = 'symbol'
 
 


### PR DESCRIPTION
If no securities were found with the entered token, the 'security' key does not exist. This causes errors later on. To fix this error, in that case I set self._key to an empty list.