### PR TITLE
Fix _parse_response function in the case that self._key is not a list

### DIFF
--- a/pytradier/base.py
+++ b/pytradier/base.py
@@ -75,6 +75,8 @@ class Base(object):
 
         response_load = {}
 
+        if type(self._key) is not list:
+            self._key = [self._key]
         for response in self._key:
             # more than one symbol supplied, loop through each one
             if attribute in list(response.keys()):


### PR DESCRIPTION
In the case where only one object of a key is returned, tradier does not wrap the object in a list (as in the case when many objects are returned). This is a byproduct of the json format mentioned here: https://documentation.tradier.com/brokerage-api/overview/response-format.

For example, this issue is most obvious in the lookup file. If a ticker is looked up, and only one ticker is returned (ex GOOGL), self._key is just a json object. However, _parse_response expects self._key to be a list of objects, resulting in an AttributeError: 'str' object has no attribute 'keys' upon calling tradier.market.lookup(symbol="GOOGL").

The solution is to simply wrap self._key in a list if self._key happens not to be a list.