### PR TITLE
Enable paper trading accounts to use the full API

### DIFF
--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -14,7 +14,7 @@ The initialization for ``Tradier`` takes three parameters:
 
 * ``token`` Your API access token provided by Tradier. *Required.*
 * ``account_id`` The ID number associated with your Tradier Brokerage account. You will only have this if you have opened a Brokerage account with Tradier. *Optional.*
-* ``sandbox`` Determines whether the sandbox or full API endpoint will be used. Sandbox has limited access, but it completely free. The full API requires a Brokerage account. *Optional.*
+* ``endpoint`` Determines whether the developer sandbox, brokerage sandbox, or full API endpoint will be used. Developer sandbox has limited access, but is completely free. The full API requires a Brokerage account. Brokerage accounts also come with a sandbox account for paper trading and has the capabilites of the full API. *Optional.*
 
 Once the ``Tradier`` class has been initialized, all submodules can be called like this:
 

--- a/pytradier/account/account.py
+++ b/pytradier/account/account.py
@@ -17,9 +17,9 @@ class Account(Base):
 	def __init__(self):
 		Base.__init__(self)
 
-		if os.environ['API_ENDPOINT'] != API_ENDPOINT['brokerage']:
-			# This part of the API only works with the full brokerage API, so require the 'brokerage' API endpoint.
-			raise ClientException('Bad Endpoint: account paths require the full API (no sandbox!)')
+		if os.environ['API_ENDPOINT'] not in [API_ENDPOINT['brokerage'], API_ENDPOINT['brokerage_sandbox']]:
+			# This part of the API only works with the full brokerage API, so require a 'brokerage' API endpoint.
+			raise ClientException('Bad Endpoint: account paths require the full API or brokerage sandbox (no developer sandbox!)')
 
 	def balance(self):
 		return Balance()

--- a/pytradier/base.py
+++ b/pytradier/base.py
@@ -24,7 +24,7 @@ class Base(object):
         """ Retrieve the requested data from Tradier. This is the main function called by other classes to retrieve information.
         
         :param endpoint: The desired endpoint. By default, this is passed in from the intialization of the ``Tradier`` class.
-            Accepts ``'sandbox'`` or ``'api'``.
+            Accepts ``'developer_sandbox'``, ``'brokerage_sandbox'``, or ``'brokerage'``.
         :param path: The API path to information. By default, this is passed in from the inheriting class's endpoint. Endpoints
             are in the form ``/v1/markets/quotes``.
         :param payload: A dictionary of the information required to send to Tradier for API calls. For example, the Market Data endpoint

--- a/pytradier/company/stats.py
+++ b/pytradier/company/stats.py
@@ -1,5 +1,5 @@
-from pytradier import base
-from pytradier.const import API_ENDPOINT, API_PATH
+from .. import base
+from ..const import API_ENDPOINT, API_PATH
 
 class Stats:
 

--- a/pytradier/const.py
+++ b/pytradier/const.py
@@ -1,7 +1,8 @@
 # Constants for Tradier.com
 
 API_ENDPOINT = {
-	'sandbox': 'https://sandbox.tradier.com',  # /v1/ paths
+	'developer_sandbox': 'https://sandbox.tradier.com',  # /v1/ paths
+	'brokerage_sandbox': 'https://sandbox.tradier.com',  # /v1/ paths, paper trading (has full capabilities of brokerage)
 	'brokerage': 'https://api.tradier.com',  # /v1/ paths
 	'stream': 'https://stream.tradier.com',  # /v1/ paths
 	'beta': 'https://api.tradier.com'  # /beta/ paths

--- a/pytradier/tradier.py
+++ b/pytradier/tradier.py
@@ -24,7 +24,7 @@ class Tradier:
         :param account_id: The ID associated with your Tradier brokerage account. If not provided, you will only
         be able to access market data. 
         :param endpoint: The chosen endpoint. If not provided, it defaults to using the full API. For developer only
-        accounts, you must specify ``endpoint='sandbox'``.
+        accounts, you must specify ``endpoint='developer_sandbox'``.
         
         An instance of the ``Tradier`` class must be created in order to access any part of the Tradier API,
         since the API is protected and the ``Tradier`` class contains your access token, account ID, and endpoint. 
@@ -56,7 +56,7 @@ class Tradier:
 
 
         if endpoint is None:  # user did not specify an endpoint
-            os.environ['API_ENDPOINT'] = API_ENDPOINT['sandbox']  # default endpoint is the sandbox
+            os.environ['API_ENDPOINT'] = API_ENDPOINT['developer_sandbox']  # default endpoint is the developer_sandbox
 
         else:
             try:


### PR DESCRIPTION
Tradier provides a paper trading account (via the sandbox endpoint) with every brokerage account. The paper trading account uses https://sandbox.tradier.com, however it has the full capabilities of the brokerage account. Because the developer sandbox and paper trading (brokerage sandbox) accounts utilize the same sandbox endpoint, I separately label them developer_sandbox and brokerage_sandbox, but with the same value https://sandbox.tradier.com.

For example, in the Account and Trading sections, Tradier notes "If you're developing in the sandbox, change the hostname to https://sandbox.tradier.com".  This note is for paper trading accounts.