### PR TITLE
Set up pytradier as a package

### DIFF
--- a/pytradier/market/status.py
+++ b/pytradier/market/status.py
@@ -59,10 +59,10 @@ class Status(Base):
         if 'style' in list(config.keys()):
             # user has specified style of time response
 
-            if config['style'] is 'epoch':
+            if config['style'] == 'epoch':
                 return response  # API returns Unix epoch by default, so return raw response time value
 
-            if config['style'] is 'pretty':  # useful for displaying the timestamp
+            if config['style'] == 'pretty':  # useful for displaying the timestamp
                 return time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(response))
 
         else:

--- a/pytradier/securities/quote.py
+++ b/pytradier/securities/quote.py
@@ -35,7 +35,7 @@ class Quote(Base):
 
 		response_load = {}
 
-		if len(self._symbols) is 1:
+		if len(self._symbols) == 1:
 			# if there is only one symbol supplied, add it to the dictionary
 			response_load[self._data['quotes']['quote']['symbol']] = self._data['quotes']['quote'][attribute]
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="pytradier",
+    version="0.0.1",
+    author="Robert Leonard",
+    description="Unofficial library for interacting with Tradier brokerage",
+    license='GPL-3.0',
+    author_email="",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/rleonard21/pytradier.git",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        "requests>=2.23.0"
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)


### PR DESCRIPTION
Hi there, I’ve added a setup.py to this repo so that pytradier can be installed as a package. In particular, I’m hoping that once this is merged in, we can upload the package to pypi!